### PR TITLE
Fixing unused import in fuzzer

### DIFF
--- a/parser_fuzz.go
+++ b/parser_fuzz.go
@@ -4,7 +4,6 @@ package ipfix
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 


### PR DESCRIPTION
Fixing import so that we can use go-fuzz