### PR TITLE
Trying to make IPFix parsing faster 24% speedup

### DIFF
--- a/.github/workflows/golang-testing.yml
+++ b/.github/workflows/golang-testing.yml
@@ -1,0 +1,39 @@
+# This workflow is designed to setup a golang workspace and execute the unit tests
+
+name: golang-testing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Executing on  ${{ runner.os }} due to ${{ github.event_name }}"
+    - run: echo "Branch is ${{ github.ref }} executing on  ${{ runner.os }} due to ${{ github.event_name }}"
+
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.7
+        cache: true
+
+    - name: Go Tidy
+      run: go mod tidy && git diff --exit-code
+
+    - name: Go Mod
+      run: go mod download
+
+    - name: Go Mod Verify
+      run: go mod verify
+
+    - name: Build
+      run: go test -v
+
+    - name: Final status
+      run: echo "Status is ${{ job.status }} 🚀"

--- a/filter.go
+++ b/filter.go
@@ -18,7 +18,6 @@ type Filter struct {
 	HeaderFilter
 	uint16Bitmask
 	baseEnabled bool
-	baseCount   uint
 	others      []otherFilter
 }
 
@@ -51,10 +50,7 @@ func (f *Filter) FilterHeader(did uint32, ver uint16) bool {
 
 func (f *Filter) Set(eid uint32, id uint16) {
 	if eid == 0 {
-		if !f.isset(id) {
-			f.set(id)
-			f.baseCount++
-		}
+		f.set(id)
 		f.baseEnabled = true
 		return
 	} else {

--- a/parser_fuzz.go
+++ b/parser_fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package ipfix

--- a/walker.go
+++ b/walker.go
@@ -214,7 +214,7 @@ func (w *Walker) handleDataRecord(r *Record, sh *setHeader, tpl []TemplateFieldS
 				if len(sl.bs) < 2 {
 					return ErrRead
 				}
-				l = int((uint16(sl.bs[0]) << 8) + uint16(sl.bs[1]))
+				l = int((uint16(sl.bs[0]) << 8) | uint16(sl.bs[1]))
 				sl.bs = sl.bs[2:]
 			}
 		}

--- a/walker.go
+++ b/walker.go
@@ -203,19 +203,32 @@ func (w *Walker) handleDataRecord(r *Record, sh *setHeader, tpl []TemplateFieldS
 	r.EndOfRecord = false
 
 	for i := range tpl {
-		if tpl[i].Length == 0xffff {
-			if lo = sl.Uint8(); lo < 0xff {
-				l = int(lo)
-			} else {
-				l = int(sl.Uint16())
+		if l = int(tpl[i].Length); l == 0xffff {
+			if len(sl.bs) == 0 {
+				return ErrRead
 			}
-		} else {
-			l = int(tpl[i].Length)
+			if lo = sl.bs[0]; lo < 0xff {
+				l = int(lo)
+				sl.bs = sl.bs[1:]
+			} else {
+				if len(sl.bs) < 2 {
+					return ErrRead
+				}
+				l = int((uint16(sl.bs[0]) << 8) + uint16(sl.bs[1]))
+				sl.bs = sl.bs[2:]
+			}
 		}
+		if l > len(sl.bs) {
+			return ErrRead
+		}
+		val = sl.bs[:l]
+		sl.bs = sl.bs[l:]
+		/* old code using this cut nonsense
 		val = sl.Cut(l)
 		if err = sl.Error(); err != nil {
 			return err
 		}
+		*/
 		if w.filtering && !w.f.IsSet(tpl[i].EnterpriseID, tpl[i].FieldID) {
 			continue //not looking at this item
 		}


### PR DESCRIPTION
What I did:

- Change the uint16Bitmask from a byte array inside a struct to just a byte array (**6% speedup**)
- Remove the slice object stuff from the hot path, just operate and check the slice directly (**18% speedup**)
- Add actions tests


This won't make any HUGE differences, but 24% is 24%...


## Before
```
GOMAXPROCS=1 go test -bench=BenchmarkFilterWalk -count=10
goos: linux
goarch: amd64
pkg: github.com/gravwell/ipfix
cpu: AMD Ryzen 7 3700X 8-Core Processor             
BenchmarkFilterWalk       460162              2719 ns/op        236978538.83 MB/s
BenchmarkFilterWalk       462705              2688 ns/op        241003555.30 MB/s
BenchmarkFilterWalk       461238              2726 ns/op        236840863.71 MB/s
BenchmarkFilterWalk       458752              2728 ns/op        235405923.47 MB/s
BenchmarkFilterWalk       460761              2710 ns/op        238067220.26 MB/s
BenchmarkFilterWalk       448224              2684 ns/op        233786313.57 MB/s
BenchmarkFilterWalk       459219              2730 ns/op        235511427.96 MB/s
BenchmarkFilterWalk       455536              2692 ns/op        236927802.73 MB/s
BenchmarkFilterWalk       463518              2680 ns/op        242156420.87 MB/s
BenchmarkFilterWalk       465410              2683 ns/op        242839800.41 MB/s
PASS
ok      github.com/gravwell/ipfix       15.616s
```

## After
```
GOMAXPROCS=1 go test -bench=BenchmarkFilterWalk -count=10
goos: linux
goarch: amd64
pkg: github.com/gravwell/ipfix
cpu: AMD Ryzen 7 3700X 8-Core Processor             
BenchmarkFilterWalk       554418              2102 ns/op        369241974.62 MB/s
BenchmarkFilterWalk       584043              2128 ns/op        384192021.31 MB/s
BenchmarkFilterWalk       568914              2190 ns/op        363707501.88 MB/s
BenchmarkFilterWalk       563606              2154 ns/op        366384547.92 MB/s
BenchmarkFilterWalk       583837              2088 ns/op        391551878.59 MB/s
BenchmarkFilterWalk       507873              2166 ns/op        328224198.60 MB/s
BenchmarkFilterWalk       582630              2082 ns/op        391840488.59 MB/s
BenchmarkFilterWalk       570936              2089 ns/op        382681439.99 MB/s
BenchmarkFilterWalk       578288              2084 ns/op        388495258.11 MB/s
BenchmarkFilterWalk       577342              2096 ns/op        385571534.90 MB/s
PASS
ok      github.com/gravwell/ipfix       15.257s

```